### PR TITLE
feat: absorb the parent's provisions drift, then harden the three Dockerfiles

### DIFF
--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/.env.template
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/.env.template
@@ -1,16 +1,33 @@
 
 # Supabase Configuration
+SUPABASE_URL=https://supabase.cataclysmstudios.net
+SUPABASE_ANON_KEY=cataclysm-anon-key
+SUPABASE_SERVICE_KEY=cataclysm-service-role-key
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_KEY=your-service-role-key
+SUPABASE_JELLYFIN_BACKUP_BUCKET=jellyfin-backups
+SUPABASE_JELLYFIN_BACKUP_PREFIX=jellyfin
+
 
 # Optional: Custom domains
 JELLYFIN_DOMAIN=localhost
 API_DOMAIN=localhost
 
+
+# Optional: Custom domains
+JELLYFIN_DOMAIN=media.cataclysmstudios.net
+API_DOMAIN=api.cataclysmstudios.net
+
 # Security (change these!)
-JWT_SECRET=your-jwt-secret-here
-NEO4J_PASSWORD=mediapassword123
+JWT_SECRET=cataclysm-jellyfin-secret
+NEO4J_PASSWORD=cataclysm-media-pass
+JELLYFIN_USERNAME=cataclysm-admin
+JELLYFIN_PASSWORD=cataclysm-change-me
+
+# Optionally use an API key instead of username/password
+JELLYFIN_API_KEY=
+# JELLYFIN_USER_ID=00000000000000000000000000000000
 
 # AI Configuration
 OPENAI_API_KEY=your-openai-key-if-needed

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/api-gateway/Dockerfile
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/api-gateway/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 
@@ -14,5 +14,17 @@ COPY . .
 RUN mkdir -p /app/logs
 
 EXPOSE 3000
+
+
+# Install curl for healthcheck
+RUN apk add --no-cache curl
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD curl -f http://localhost:3000/health || exit 1
+# Non-root. Alpine ships an unused uid 1000 `node`; PMOVES pins 65532 to match
+# the rest of the fleet so compose `user:` overrides are uniform.
+RUN addgroup -g 65532 -S pmoves     && adduser -u 65532 -S -G pmoves -h /app -s /sbin/nologin pmoves     && chown -R 65532:65532 /app
+USER pmoves:pmoves
 
 CMD ["npm", "start"]

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/api-gateway/package-lock.json
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/api-gateway/package-lock.json
@@ -1,0 +1,1778 @@
+{
+  "name": "media-api-gateway",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "media-api-gateway",
+      "version": "1.0.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.38.4",
+        "axios": "^1.18.0",
+        "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
+        "express": "^4.22.1",
+        "express-rate-limit": "^7.1.5",
+        "helmet": "^7.1.0",
+        "jsonwebtoken": "^9.0.3",
+        "morgan": "^1.11.0",
+        "multer": "^2.2.0",
+        "neo4j-driver": "^5.15.0",
+        "redis": "^4.6.10",
+        "ws": "^8.21.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.6",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/morgan": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+      "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.4.1",
+        "on-headers": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/neo4j-driver": {
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-5.28.2.tgz",
+      "integrity": "sha512-nix4Canllf7Tl4FZL9sskhkKYoCp40fg7VsknSRTRgbm1JaE2F1Ej/c2nqlM06nqh3WrkI0ww3taVB+lem7w7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "neo4j-driver-bolt-connection": "5.28.2",
+        "neo4j-driver-core": "5.28.2",
+        "rxjs": "^7.8.2"
+      }
+    },
+    "node_modules/neo4j-driver-bolt-connection": {
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-bolt-connection/-/neo4j-driver-bolt-connection-5.28.2.tgz",
+      "integrity": "sha512-dEX06iNPEo9iyCb0NssxJeA3REN+H+U/Y0MdAjJBEoil4tGz5PxBNZL6/+noQnu2pBJT5wICepakXCrN3etboA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "neo4j-driver-core": "5.28.2",
+        "string_decoder": "^1.3.0"
+      }
+    },
+    "node_modules/neo4j-driver-core": {
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/neo4j-driver-core/-/neo4j-driver-core-5.28.2.tgz",
+      "integrity": "sha512-fBMk4Ox379oOz4FcfdS6ZOxsTEypjkcAelNm9LcWQZ981xCdOnGMzlWL+qXECvL0qUwRfmZxoqbDlJzuzFrdvw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/api-gateway/package.json
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/api-gateway/package.json
@@ -8,19 +8,22 @@
     "dev": "nodemon server.js"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "cors": "^2.8.5",
-    "helmet": "^7.1.0",
-    "morgan": "^1.10.0",
-    "axios": "^1.6.2",
     "@supabase/supabase-js": "^2.38.4",
+    "axios": "^1.18.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.22.1",
+    "express-rate-limit": "^7.1.5",
+    "helmet": "^7.1.0",
+    "jsonwebtoken": "^9.0.3",
+    "morgan": "^1.11.0",
+    "multer": "^2.2.0",
     "neo4j-driver": "^5.15.0",
     "redis": "^4.6.10",
-    "multer": "^1.4.5-lts.1",
-    "express-rate-limit": "^7.1.5",
-    "jsonwebtoken": "^9.0.2",
-    "dotenv": "^16.3.1",
-    "ws": "^8.14.2"
+    "ws": "^8.21.2"
+  },
+  "overrides": {
+    "qs": "6.14.2"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/api-gateway/server.js
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/api-gateway/server.js
@@ -9,10 +9,15 @@ const neo4j = require('neo4j-driver');
 const Redis = require('redis');
 const axios = require('axios');
 const WebSocket = require('ws');
+const fs = require('fs/promises');
+const path = require('path');
 require('dotenv').config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+
+// Only trust proxy headers when explicitly enabled by deployment.
+app.set('trust proxy', process.env.TRUST_PROXY === '1' ? 1 : false);
 
 // Security middleware
 app.use(helmet());
@@ -38,7 +43,7 @@ app.use(express.urlencoded({ extended: true }));
 // Initialize clients
 const supabase = createClient(
   process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_KEY
+  process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY
 );
 
 const neo4jDriver = neo4j.driver(
@@ -50,7 +55,202 @@ const redisClient = Redis.createClient({
   url: process.env.REDIS_URL || 'redis://redis:6379'
 });
 
-redisClient.connect();
+redisClient.connect().catch((err) => {
+  console.error('Redis connection error:', err);
+});
+
+const MIGRATION_RESULTS_KEY = process.env.MIGRATION_RESULTS_KEY || 'jellyfin:migration:runs';
+const MIGRATION_RESULTS_PATH = process.env.MIGRATION_RESULTS_PATH;
+const BRIDGE_LOG_PATH = process.env.BRIDGE_LOG_PATH;
+const PUBLISHER_LOG_PATH = process.env.PUBLISHER_LOG_PATH;
+const BRIDGE_LOG_KEY = process.env.BRIDGE_LOG_KEY || 'logs:jellyfin-bridge';
+const PUBLISHER_LOG_KEY = process.env.PUBLISHER_LOG_KEY || 'logs:publisher';
+const LOG_EXCERPT_LINES = parseInt(process.env.LOG_EXCERPT_LINES || '200', 10);
+
+async function readJsonFile(filePath) {
+  if (!filePath) return null;
+  try {
+    const resolved = path.resolve(filePath);
+    const raw = await fs.readFile(resolved, 'utf8');
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+    console.error('Failed to read migration results file:', error);
+    throw error;
+  }
+}
+
+async function safeRedisListFetch(key, start = 0, end = -1) {
+  if (!redisClient?.isOpen) return [];
+  try {
+    return await redisClient.lRange(key, start, end);
+  } catch (error) {
+    console.warn(`Redis read failed for key ${key}:`, error.message);
+    return [];
+  }
+}
+
+function normalizeMigrationResult(payload) {
+  if (!payload) return null;
+
+  if (Array.isArray(payload)) {
+    return normalizeMigrationResult(payload[0]);
+  }
+
+  if (payload?.runs && Array.isArray(payload.runs)) {
+    const sorted = [...payload.runs].sort((a, b) => {
+      const aTime = new Date(a.completed_at || a.created_at || a.timestamp || 0).getTime();
+      const bTime = new Date(b.completed_at || b.created_at || b.timestamp || 0).getTime();
+      return bTime - aTime;
+    });
+    return normalizeMigrationResult(sorted[0]);
+  }
+
+  return payload;
+}
+
+function deriveChecklist(migrationResult) {
+  if (!migrationResult) {
+    return [
+      {
+        id: 'supabase-migrations',
+        label: 'Supabase migrations applied',
+        completed: false,
+        detail: 'Awaiting latest migration run.'
+      },
+      {
+        id: 'neo4j-sync',
+        label: 'Neo4j media graph refreshed',
+        completed: false
+      },
+      {
+        id: 'bridge-health',
+        label: 'Jellyfin bridge responding',
+        completed: false
+      },
+      {
+        id: 'publisher-health',
+        label: 'Publisher webhooks draining queue',
+        completed: false
+      }
+    ];
+  }
+
+  if (Array.isArray(migrationResult.checklist)) {
+    return migrationResult.checklist.map((item, index) => ({
+      id: item.id || `check-${index}`,
+      label: item.label || item.name || `Check ${index + 1}`,
+      completed: item.completed ?? item.status === 'ok' ?? false,
+      detail: item.detail || item.notes || null
+    }));
+  }
+
+  const checklist = [];
+  const supabaseStatus = migrationResult.supabase?.status || migrationResult.supabase_status;
+  const neo4jStatus = migrationResult.neo4j?.status || migrationResult.neo4j_status;
+  const bridgeStatus = migrationResult.bridge?.status || migrationResult.bridge_status;
+  const publisherStatus = migrationResult.publisher?.status || migrationResult.publisher_status;
+
+  checklist.push({
+    id: 'supabase-migrations',
+    label: 'Supabase migrations applied',
+    completed: (supabaseStatus || '').toLowerCase() === 'ok'
+  });
+  checklist.push({
+    id: 'neo4j-sync',
+    label: 'Neo4j media graph refreshed',
+    completed: (neo4jStatus || '').toLowerCase() === 'ok'
+  });
+  checklist.push({
+    id: 'bridge-health',
+    label: 'Jellyfin bridge responding',
+    completed: (bridgeStatus || '').toLowerCase() === 'ok'
+  });
+  checklist.push({
+    id: 'publisher-health',
+    label: 'Publisher webhooks draining queue',
+    completed: (publisherStatus || '').toLowerCase() === 'ok'
+  });
+
+  return checklist;
+}
+
+function deriveWebhookLatency(migrationResult) {
+  if (!migrationResult) return null;
+
+  if (migrationResult.metrics?.webhookLatency) {
+    return migrationResult.metrics.webhookLatency;
+  }
+
+  if (migrationResult.webhookLatency) {
+    return migrationResult.webhookLatency;
+  }
+
+  const latencyFields = ['webhook_latency_ms', 'webhook_latency'];
+  for (const field of latencyFields) {
+    if (field in migrationResult) {
+      return {
+        averageMs: Number(migrationResult[field]) || null
+      };
+    }
+  }
+
+  return null;
+}
+
+async function fetchLatestMigrationResult() {
+  const [redisEntry] = await safeRedisListFetch(MIGRATION_RESULTS_KEY, 0, 0);
+
+  if (redisEntry) {
+    try {
+      const parsed = JSON.parse(redisEntry);
+      return normalizeMigrationResult(parsed);
+    } catch (error) {
+      console.warn('Failed to parse migration result from Redis:', error.message);
+    }
+  }
+
+  const filePayload = await readJsonFile(MIGRATION_RESULTS_PATH);
+  if (filePayload) {
+    return normalizeMigrationResult(filePayload);
+  }
+
+  return null;
+}
+
+async function tailFile(filePath, lines) {
+  if (!filePath) return null;
+  try {
+    const resolved = path.resolve(filePath);
+    const contents = await fs.readFile(resolved, 'utf8');
+    const entries = contents.split(/\r?\n/).filter(Boolean);
+    return entries.slice(-lines);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
+    }
+    console.error(`Failed to read log file at ${filePath}:`, error);
+    throw error;
+  }
+}
+
+async function getLogExcerpt(options = {}, lines = LOG_EXCERPT_LINES) {
+  const { filePath, redisKey } = options;
+  const redisEntries = redisKey ? await safeRedisListFetch(redisKey, 0, lines - 1) : [];
+
+  if (redisEntries.length) {
+    return { source: 'redis', entries: redisEntries };
+  }
+
+  const fileEntries = await tailFile(filePath, lines);
+  if (fileEntries && fileEntries.length) {
+    return { source: 'file', entries: fileEntries };
+  }
+
+  return { source: redisEntries.length ? 'redis' : 'file', entries: [] };
+}
 
 // WebSocket server for real-time updates
 const wss = new WebSocket.Server({ port: 3002 });
@@ -278,6 +478,51 @@ app.get('/api/analytics', async (req, res) => {
   } catch (error) {
     console.error('Error getting analytics:', error);
     res.status(500).json({ error: error.message });
+  }
+});
+
+app.get('/api/migrations/latest', async (req, res) => {
+  try {
+    const migrationResult = await fetchLatestMigrationResult();
+    const checklist = deriveChecklist(migrationResult);
+    const webhookLatency = deriveWebhookLatency(migrationResult);
+
+    res.json({
+      run: migrationResult,
+      checklist,
+      webhookLatency,
+      source: migrationResult ? 'available' : 'unavailable'
+    });
+  } catch (error) {
+    console.error('Error fetching migration results:', error);
+    res.status(500).json({ error: 'Failed to load migration results' });
+  }
+});
+
+app.get('/api/logs/:service', async (req, res) => {
+  const { service } = req.params;
+  const lines = parseInt(req.query.lines, 10) || LOG_EXCERPT_LINES;
+
+  const config = {
+    bridge: { filePath: BRIDGE_LOG_PATH, redisKey: BRIDGE_LOG_KEY },
+    publisher: { filePath: PUBLISHER_LOG_PATH, redisKey: PUBLISHER_LOG_KEY }
+  }[service];
+
+  if (!config) {
+    return res.status(404).json({ error: 'Unknown log service requested' });
+  }
+
+  try {
+    const excerpt = await getLogExcerpt(config, lines);
+    res.json({
+      service,
+      lines,
+      entries: excerpt.entries,
+      source: excerpt.source
+    });
+  } catch (error) {
+    console.error(`Error fetching ${service} logs:`, error);
+    res.status(500).json({ error: `Failed to load ${service} logs` });
   }
 });
 

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/audio-processor/Dockerfile
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/audio-processor/Dockerfile
@@ -1,8 +1,23 @@
 FROM python:3.11-slim AS ffmpeg-downloader
 
-ARG FFMPEG_VERSION=7.1
-ARG FFMPEG_ARCHIVE=ffmpeg-n${FFMPEG_VERSION}-latest-linux64-gpl-${FFMPEG_VERSION}.tar.xz
-ARG FFMPEG_ARCHIVE_DIR=ffmpeg-n${FFMPEG_VERSION}-latest-linux64-gpl-${FFMPEG_VERSION}
+# 8.1, not 7.1. This downloads from BtbN's ROLLING `latest` release tag, which
+# only carries the versions currently being built -- today master, n8.1 and
+# n9.0. n7.1 has aged out of it, so the pinned 7.1 URL returns 404 on EVERY
+# architecture and this image cannot build at all. Verified: both 8.1 archives
+# return 200, both 7.1 archives return 404.
+#
+# The coupling is the real hazard: a version pin against a rolling tag is not a
+# pin, and this will break again when 8.1 ages out. Either keep this value in
+# the set `latest` still publishes, or switch to a dated autobuild tag for a
+# genuine pin.
+ARG FFMPEG_VERSION=8.1
+# TARGETARCH is supplied by buildx. The archive slug was hardcoded to linux64,
+# which put x86-64 binaries on ARM64 nodes (Jetson, SPARK) -- and because the
+# runtime stage below prepends /opt/ffmpeg/bin to PATH, they did not merely sit
+# unused, they SHADOWED the architecture-native ffmpeg. The slug appears in both
+# the archive name and the extracted directory name, so it has to be resolved
+# before either is formed.
+ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -13,11 +28,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${FFMPEG_ARCHIVE}" -o /tmp/ffmpeg.tar.xz \
-    && mkdir -p /opt \
-    && tar -xJf /tmp/ffmpeg.tar.xz -C /opt \
-    && mv /opt/${FFMPEG_ARCHIVE_DIR} /opt/ffmpeg \
-    && rm -f /tmp/ffmpeg.tar.xz
+# Fails closed on an unrecognised architecture rather than falling back to
+# linux64. A silent x86 default is exactly how this reaches an ARM node and
+# only surfaces at the first transcode.
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) FFMPEG_ARCH=linux64 ;; \
+      arm64) FFMPEG_ARCH=linuxarm64 ;; \
+      *) echo "Unsupported TARGETARCH for FFmpeg build: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    FFMPEG_SLUG="ffmpeg-n${FFMPEG_VERSION}-latest-${FFMPEG_ARCH}-gpl-${FFMPEG_VERSION}"; \
+    curl -fsSL "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${FFMPEG_SLUG}.tar.xz" -o /tmp/ffmpeg.tar.xz; \
+    mkdir -p /opt; \
+    tar -xJf /tmp/ffmpeg.tar.xz -C /opt; \
+    mv "/opt/${FFMPEG_SLUG}" /opt/ffmpeg; \
+    rm -f /tmp/ffmpeg.tar.xz; \
+    # Smoke the binary in the stage that produced it, so a wrong-architecture
+    # download fails the build instead of the first transcode.
+    /opt/ffmpeg/bin/ffmpeg -version | head -1
 
 FROM python:3.11-slim
 

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/audio-processor/Dockerfile
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/audio-processor/Dockerfile
@@ -1,13 +1,47 @@
+FROM python:3.11-slim AS ffmpeg-downloader
+
+ARG FFMPEG_VERSION=7.1
+ARG FFMPEG_ARCHIVE=ffmpeg-n${FFMPEG_VERSION}-latest-linux64-gpl-${FFMPEG_VERSION}.tar.xz
+ARG FFMPEG_ARCHIVE_DIR=ffmpeg-n${FFMPEG_VERSION}-latest-linux64-gpl-${FFMPEG_VERSION}
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Download the pinned FFmpeg 7.1 build with HDR/AV1/NVENC/VAAPI support
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${FFMPEG_ARCHIVE}" -o /tmp/ffmpeg.tar.xz \
+    && mkdir -p /opt \
+    && tar -xJf /tmp/ffmpeg.tar.xz -C /opt \
+    && mv /opt/${FFMPEG_ARCHIVE_DIR} /opt/ffmpeg \
+    && rm -f /tmp/ffmpeg.tar.xz
 
 FROM python:3.11-slim
 
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/opt/ffmpeg/bin:${PATH}"
+
 WORKDIR /app
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    ffmpeg \
+# Runtime dependencies required for audio processing and GPU detection utilities
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     curl \
+    libasound2 \
+    libdrm2 \
+    libsndfile1 \
+    libva2 \
+    libva-drm2 \
+    libva-x11-2 \
+    libvdpau1 \
+    ocl-icd-libopencl1 \
+    vainfo \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ffmpeg-downloader /opt/ffmpeg /opt/ffmpeg
 
 # Copy requirements first for better caching
 COPY requirements.txt .
@@ -23,5 +57,16 @@ RUN mkdir -p /app/logs /app/output /app/temp
 RUN chmod +x /app/entrypoint.sh
 
 EXPOSE 8001
+
+
+# Health check (process-based for non-HTTP worker)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD test -f /proc/1/cmdline || exit 1
+# Run as a non-root user. The hardening ratchet judges the LAST USER directive,
+# and uid/gid 65532 is the PMOVES convention (see services/agent-zero and
+# services/gateway-agent). Ownership is set explicitly rather than with a late
+# recursive chown so the layer stays small.
+RUN groupadd -r pmoves --gid=65532     && useradd -r -g pmoves --uid=65532 --home-dir=/app --shell=/sbin/nologin pmoves     && chown -R 65532:65532 /app
+USER pmoves:pmoves
 
 CMD ["./entrypoint.sh"]

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/audio-processor/main.py
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/audio-processor/main.py
@@ -1,269 +1,516 @@
-
 import asyncio
-import os
-import logging
-from pathlib import Path
-from typing import Dict, List, Optional
 import json
-import time
+import logging
+import os
+from typing import Any, Dict, List, Optional
 
 import httpx
-from supabase import create_client, Client
-from neo4j import GraphDatabase
-import redis
-from pydub import AudioSegment
 import librosa
-import numpy as np
+import redis
+from neo4j import GraphDatabase
+from supabase import Client, create_client
 
-# Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+DEFAULT_ANALYSIS_PROMPT = (
+    "Analyze this audio content. Describe the genre, mood, instruments, "
+    "vocals, and any notable characteristics."
+)
+
+
+class JellyfinAuthError(Exception):
+    """Raised when Jellyfin authentication fails."""
+
+
+class AIProviderError(Exception):
+    """Raised when an audio AI provider request fails."""
+
+
+def _build_auth_payload(username: str, password: str) -> Dict[str, str]:
+    device_name = os.getenv("JELLYFIN_CLIENT_DEVICE", "pmoves-jellyfin-audio-processor")
+    device_id = os.getenv("JELLYFIN_CLIENT_DEVICE_ID", device_name)
+    return {
+        "Username": username,
+        "Pw": password,
+        "App": os.getenv("JELLYFIN_CLIENT_APP", "PMOVES Audio Processor"),
+        "Device": device_name,
+        "DeviceId": device_id,
+        "DeviceName": device_name,
+        "Version": os.getenv("JELLYFIN_CLIENT_VERSION", "0.0.0"),
+    }
+
+
 class MediaProcessor:
-    def __init__(self):
-        self.jellyfin_url = os.getenv("JELLYFIN_URL", "http://jellyfin:8096")
+    def __init__(self, skip_external_clients: bool = False):
+        self.jellyfin_url = os.getenv("JELLYFIN_URL", "http://jellyfin:8096").rstrip("/")
+        self.jellyfin_username = os.getenv("JELLYFIN_USERNAME")
+        self.jellyfin_password = os.getenv("JELLYFIN_PASSWORD")
+        self.jellyfin_api_key = os.getenv("JELLYFIN_API_KEY")
+        self._jellyfin_headers: Optional[Dict[str, str]] = None
+
         self.supabase_url = os.getenv("SUPABASE_URL")
-        self.supabase_key = os.getenv("SUPABASE_ANON_KEY")
-        self.neo4j_uri = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
+        self.supabase_key = (
+            os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            or os.getenv("SUPABASE_SERVICE_KEY")
+            or os.getenv("SUPABASE_ANON_KEY")
+        )
+        self.neo4j_uri = os.getenv("NEO4J_URI", "bolt://jellyfin-neo4j:7687")
         self.neo4j_user = os.getenv("NEO4J_USER", "neo4j")
         self.neo4j_password = os.getenv("NEO4J_PASSWORD", "mediapassword123")
-        self.qwen_url = os.getenv("QWEN_AUDIO_URL", "http://qwen-audio:8000")
+        self.redis_host = os.getenv("REDIS_HOST", "jellyfin-redis")
+        self.redis_port = int(os.getenv("REDIS_PORT", "6379"))
 
-        # Initialize clients
-        if self.supabase_url and self.supabase_key:
-            self.supabase: Client = create_client(self.supabase_url, self.supabase_key)
+        self.audio_provider = os.getenv("AUDIO_AI_PROVIDER", "auto").strip().lower()
+        self.allow_cross_fallback = os.getenv("AUDIO_AI_ALLOW_CROSS_FALLBACK", "1") == "1"
+        self.analysis_timeout = float(os.getenv("AUDIO_AI_TIMEOUT_SECONDS", "300"))
+        self.analysis_prompt = os.getenv("AUDIO_ANALYSIS_PROMPT", DEFAULT_ANALYSIS_PROMPT)
+        self.max_tokens = int(os.getenv("AUDIO_ANALYSIS_MAX_TOKENS", "500"))
 
-        self.neo4j_driver = GraphDatabase.driver(
-            self.neo4j_uri,
-            auth=(self.neo4j_user, self.neo4j_password)
+        self.ollama_url = (
+            os.getenv("QWEN_AUDIO_URL")
+            or os.getenv("OLLAMA_AUDIO_URL")
+            or "http://jellyfin-qwen-audio:11434"
+        ).rstrip("/")
+        self.ollama_model = (
+            os.getenv("QWEN_MODEL_NAME")
+            or os.getenv("OLLAMA_MODEL_NAME")
+            or "hf.co/second-state/Qwen2-Audio-7B-Instruct-GGUF:Q4_K_M"
         )
+        self.ollama_analyze_path = os.getenv("OLLAMA_AUDIO_ANALYZE_PATH", "/analyze")
 
-        self.redis_client = redis.Redis(host='redis', port=6379, db=0)
+        self.hf_audio_url = os.getenv("HUGGINGFACE_AUDIO_URL", "").strip().rstrip("/")
+        self.hf_model_id = os.getenv("HUGGINGFACE_MODEL_ID", "openai/whisper-large-v3")
+        self.hf_api_token = os.getenv("HUGGINGFACE_API_TOKEN") or os.getenv("HF_TOKEN")
+        self.hf_wait_for_model = os.getenv("HUGGINGFACE_WAIT_FOR_MODEL", "1") == "1"
+        self.hf_task = os.getenv("HUGGINGFACE_AUDIO_TASK", "auto")
 
-    async def get_jellyfin_library(self) -> List[Dict]:
-        """Fetch media library from Jellyfin"""
+        self.supabase: Optional[Client] = None
+        self.neo4j_driver = None
+        self.redis_client = None
+
+        if not skip_external_clients:
+            self._init_clients()
+
+    def _init_clients(self) -> None:
+        if self.supabase_url and self.supabase_key:
+            try:
+                self.supabase = create_client(self.supabase_url, self.supabase_key)
+            except Exception as exc:
+                logger.warning("Supabase client disabled due to configuration error: %s", exc)
+                self.supabase = None
+
         try:
-            async with httpx.AsyncClient() as client:
-                # First, get API key or authenticate
-                auth_response = await client.post(
-                    f"{self.jellyfin_url}/Users/AuthenticateByName",
-                    json={"Username": "admin", "Pw": ""}  # Configure proper auth
+            self.neo4j_driver = GraphDatabase.driver(
+                self.neo4j_uri, auth=(self.neo4j_user, self.neo4j_password)
+            )
+        except Exception as exc:
+            logger.warning("Neo4j client disabled due to configuration error: %s", exc)
+            self.neo4j_driver = None
+
+        try:
+            self.redis_client = redis.Redis(host=self.redis_host, port=self.redis_port, db=0)
+            self.redis_client.ping()
+        except Exception as exc:
+            logger.warning("Redis client disabled due to configuration error: %s", exc)
+            self.redis_client = None
+
+    @staticmethod
+    def _extract_error_detail(response: httpx.Response) -> str:
+        try:
+            payload = response.json()
+            if isinstance(payload, dict):
+                message = payload.get("ErrorMessage") or payload.get("Message")
+                if message:
+                    return str(message)
+        except ValueError:
+            pass
+        return response.text or "Unknown error"
+
+    @staticmethod
+    def _normalize_provider_response(payload: Any, provider: str) -> Dict[str, Any]:
+        if isinstance(payload, dict):
+            text = (
+                payload.get("description")
+                or payload.get("text")
+                or payload.get("generated_text")
+                or payload.get("summary")
+            )
+            if not text and isinstance(payload.get("result"), dict):
+                text = payload["result"].get("text") or payload["result"].get("description")
+            return {
+                "provider": provider,
+                "description": text or "",
+                "analysis": payload,
+            }
+        if isinstance(payload, list):
+            if payload and isinstance(payload[0], dict):
+                return MediaProcessor._normalize_provider_response(payload[0], provider)
+            return {"provider": provider, "description": "", "analysis": payload}
+        if isinstance(payload, str):
+            return {"provider": provider, "description": payload, "analysis": {"text": payload}}
+        return {"provider": provider, "description": "", "analysis": {"raw": payload}}
+
+    async def _get_jellyfin_headers(self, client: httpx.AsyncClient) -> Dict[str, str]:
+        if self._jellyfin_headers:
+            return self._jellyfin_headers
+
+        if self.jellyfin_api_key:
+            self._jellyfin_headers = {"X-Emby-Token": self.jellyfin_api_key}
+            return self._jellyfin_headers
+
+        if not self.jellyfin_username or not self.jellyfin_password:
+            raise JellyfinAuthError(
+                "Set JELLYFIN_USERNAME/JELLYFIN_PASSWORD or JELLYFIN_API_KEY."
+            )
+
+        try:
+            auth_response = await client.post(
+                f"{self.jellyfin_url}/Users/AuthenticateByName",
+                json=_build_auth_payload(self.jellyfin_username, self.jellyfin_password),
+                # Jellyfin 10.9+ rejects AuthenticateByName without a
+                # MediaBrowser authorization header (400, not 401).
+                headers={
+                    "X-Emby-Authorization": (
+                        'MediaBrowser Client="pmoves-audio-processor", '
+                        'Device="audio-processor", '
+                        'DeviceId="pmoves-audio-processor", Version="1.0"'
+                    )
+                },
+            )
+        except httpx.HTTPError as exc:
+            raise JellyfinAuthError(f"Failed to reach Jellyfin for authentication: {exc}") from exc
+
+        if auth_response.status_code != 200:
+            detail = self._extract_error_detail(auth_response)
+            raise JellyfinAuthError(
+                f"Jellyfin authentication failed ({auth_response.status_code}): {detail}"
+            )
+
+        token = auth_response.json().get("AccessToken")
+        if not token:
+            raise JellyfinAuthError("Jellyfin authentication succeeded without access token.")
+
+        self._jellyfin_headers = {"X-Emby-Token": token}
+        return self._jellyfin_headers
+
+    async def get_jellyfin_library(self) -> List[Dict[str, Any]]:
+        try:
+            async with httpx.AsyncClient(timeout=self.analysis_timeout) as client:
+                headers = await self._get_jellyfin_headers(client)
+                items_response = await client.get(
+                    f"{self.jellyfin_url}/Items",
+                    headers=headers,
+                    params={"Recursive": True, "IncludeItemTypes": "Audio"},
                 )
 
-                if auth_response.status_code == 200:
-                    token = auth_response.json()["AccessToken"]
-                    headers = {"Authorization": f"MediaBrowser Token={token}"}
+                if items_response.status_code == 200:
+                    return items_response.json().get("Items", [])
 
-                    # Get all items
-                    items_response = await client.get(
-                        f"{self.jellyfin_url}/Items",
-                        headers=headers,
-                        params={"Recursive": True, "IncludeItemTypes": "Audio"}
-                    )
-
-                    if items_response.status_code == 200:
-                        return items_response.json()["Items"]
-
-        except Exception as e:
-            logger.error(f"Error fetching Jellyfin library: {e}")
+                logger.error(
+                    "Failed to fetch Jellyfin library (%s): %s",
+                    items_response.status_code,
+                    self._extract_error_detail(items_response),
+                )
+        except JellyfinAuthError as auth_error:
+            logger.error("Jellyfin auth error: %s", auth_error)
+        except Exception as exc:
+            logger.error("Error fetching Jellyfin library: %s", exc)
 
         return []
 
-    async def analyze_audio_with_qwen(self, audio_path: str) -> Dict:
-        """Send audio to Qwen for analysis"""
-        try:
-            async with httpx.AsyncClient(timeout=300.0) as client:
-                with open(audio_path, 'rb') as audio_file:
-                    files = {'audio': audio_file}
-                    data = {
-                        'prompt': 'Analyze this audio content. Describe the genre, mood, instruments, vocals, and any notable characteristics.',
-                        'max_tokens': 500
-                    }
+    def _provider_order(self) -> List[str]:
+        provider = self.audio_provider
+        if provider == "auto":
+            return ["ollama", "huggingface"]
+        if provider == "ollama":
+            return ["ollama", "huggingface"] if self.allow_cross_fallback else ["ollama"]
+        if provider == "huggingface":
+            return ["huggingface", "ollama"] if self.allow_cross_fallback else ["huggingface"]
+        logger.warning("Unknown AUDIO_AI_PROVIDER=%s. Falling back to auto.", provider)
+        return ["ollama", "huggingface"]
 
-                    response = await client.post(
-                        f"{self.qwen_url}/analyze",
-                        files=files,
-                        data=data
+    async def _analyze_with_ollama(self, audio_path: str) -> Dict[str, Any]:
+        analyze_url = f"{self.ollama_url}{self.ollama_analyze_path}"
+        try:
+            async with httpx.AsyncClient(timeout=self.analysis_timeout) as client:
+                with open(audio_path, "rb") as audio_file:
+                    files = {"audio": audio_file}
+                    data = {"prompt": self.analysis_prompt, "max_tokens": str(self.max_tokens)}
+                    response = await client.post(analyze_url, files=files, data=data)
+
+                if response.status_code >= 400:
+                    raise AIProviderError(
+                        f"Ollama analyze endpoint failed ({response.status_code}): "
+                        f"{self._extract_error_detail(response)}"
                     )
 
-                    if response.status_code == 200:
-                        return response.json()
+                payload = response.json()
+                return self._normalize_provider_response(payload, "ollama")
+        except FileNotFoundError as exc:
+            raise AIProviderError(f"Audio file missing: {audio_path}") from exc
+        except httpx.HTTPError as exc:
+            raise AIProviderError(f"Ollama request failed: {exc}") from exc
+        except json.JSONDecodeError as exc:
+            raise AIProviderError("Ollama returned invalid JSON.") from exc
 
-        except Exception as e:
-            logger.error(f"Error analyzing audio with Qwen: {e}")
+    async def _analyze_with_huggingface(self, audio_path: str) -> Dict[str, Any]:
+        headers: Dict[str, str] = {}
+        if self.hf_api_token:
+            headers["Authorization"] = f"Bearer {self.hf_api_token}"
 
-        return {}
+        try:
+            async with httpx.AsyncClient(timeout=self.analysis_timeout) as client:
+                if self.hf_audio_url:
+                    with open(audio_path, "rb") as audio_file:
+                        files = {"audio": audio_file}
+                        data = {
+                            "prompt": self.analysis_prompt,
+                            "max_tokens": str(self.max_tokens),
+                            "task": self.hf_task,
+                            "model": self.hf_model_id,
+                        }
+                        response = await client.post(
+                            self.hf_audio_url, headers=headers, files=files, data=data
+                        )
+                else:
+                    infer_url = f"https://api-inference.huggingface.co/models/{self.hf_model_id}"
+                    params = {"wait_for_model": "true" if self.hf_wait_for_model else "false"}
+                    with open(audio_path, "rb") as audio_file:
+                        audio_bytes = audio_file.read()
+                    response = await client.post(
+                        infer_url,
+                        headers=headers,
+                        params=params,
+                        content=audio_bytes,
+                    )
 
-    def extract_audio_features(self, audio_path: str) -> Dict:
-        """Extract technical audio features using librosa"""
+                if response.status_code >= 400:
+                    raise AIProviderError(
+                        f"HuggingFace request failed ({response.status_code}): "
+                        f"{self._extract_error_detail(response)}"
+                    )
+
+                payload = response.json()
+                return self._normalize_provider_response(payload, "huggingface")
+        except FileNotFoundError as exc:
+            raise AIProviderError(f"Audio file missing: {audio_path}") from exc
+        except httpx.HTTPError as exc:
+            raise AIProviderError(f"HuggingFace request failed: {exc}") from exc
+        except json.JSONDecodeError as exc:
+            raise AIProviderError("HuggingFace returned invalid JSON.") from exc
+
+    async def analyze_audio_with_ai(self, audio_path: str) -> Dict[str, Any]:
+        errors: List[str] = []
+        for provider in self._provider_order():
+            try:
+                if provider == "ollama":
+                    result = await self._analyze_with_ollama(audio_path)
+                else:
+                    result = await self._analyze_with_huggingface(audio_path)
+                if result.get("description") or result.get("analysis"):
+                    return result
+            except AIProviderError as exc:
+                msg = f"{provider}:{exc}"
+                errors.append(msg)
+                logger.warning("Audio provider failed (%s), trying fallback if available.", msg)
+            except Exception as exc:
+                msg = f"{provider}:unexpected:{exc}"
+                errors.append(msg)
+                logger.warning("Unexpected provider error (%s), trying fallback if available.", msg)
+
+        return {
+            "provider": "none",
+            "description": "",
+            "analysis": {"errors": errors},
+        }
+
+    def extract_audio_features(self, audio_path: str) -> Dict[str, Any]:
         try:
             y, sr = librosa.load(audio_path)
-
-            # Extract features
-            tempo, beats = librosa.beat.beat_track(y=y, sr=sr)
+            tempo, _ = librosa.beat.beat_track(y=y, sr=sr)
             mfccs = librosa.feature.mfcc(y=y, sr=sr, n_mfcc=13)
             spectral_centroids = librosa.feature.spectral_centroid(y=y, sr=sr)
             spectral_rolloff = librosa.feature.spectral_rolloff(y=y, sr=sr)
             zero_crossing_rate = librosa.feature.zero_crossing_rate(y)
-
             return {
-                'tempo': float(tempo),
-                'duration': float(len(y) / sr),
-                'mfcc_mean': mfccs.mean(axis=1).tolist(),
-                'spectral_centroid_mean': float(spectral_centroids.mean()),
-                'spectral_rolloff_mean': float(spectral_rolloff.mean()),
-                'zero_crossing_rate_mean': float(zero_crossing_rate.mean()),
-                'sample_rate': int(sr)
+                "tempo": float(tempo),
+                "duration": float(len(y) / sr),
+                "mfcc_mean": mfccs.mean(axis=1).tolist(),
+                "spectral_centroid_mean": float(spectral_centroids.mean()),
+                "spectral_rolloff_mean": float(spectral_rolloff.mean()),
+                "zero_crossing_rate_mean": float(zero_crossing_rate.mean()),
+                "sample_rate": int(sr),
             }
-
-        except Exception as e:
-            logger.error(f"Error extracting audio features: {e}")
+        except Exception as exc:
+            logger.error("Error extracting audio features: %s", exc)
             return {}
 
-    def store_in_neo4j(self, media_data: Dict, analysis_data: Dict, features: Dict):
-        """Store media and analysis data in Neo4j"""
+    def _is_processed(self, media_id: Optional[str]) -> bool:
+        if not self.redis_client or not media_id:
+            return False
+        try:
+            return bool(self.redis_client.get(f"processed:{media_id}"))
+        except Exception as exc:
+            logger.warning("Redis read failed: %s", exc)
+            return False
+
+    def _mark_processed(self, media_id: Optional[str]) -> None:
+        if not self.redis_client or not media_id:
+            return
+        try:
+            self.redis_client.setex(f"processed:{media_id}", 86400, "1")
+        except Exception as exc:
+            logger.warning("Redis write failed: %s", exc)
+
+    def store_in_neo4j(self, media_data: Dict[str, Any], analysis_data: Dict[str, Any], features: Dict[str, Any]) -> None:
+        if not self.neo4j_driver:
+            logger.info("Neo4j client not configured; skipping Neo4j storage.")
+            return
         try:
             with self.neo4j_driver.session() as session:
-                # Create media node
-                session.run("""
+                session.run(
+                    """
                     MERGE (m:Media {id: $media_id})
                     SET m.name = $name,
                         m.path = $path,
                         m.type = $type,
                         m.duration = $duration,
                         m.created_at = datetime()
-                """, 
-                media_id=media_data.get('Id'),
-                name=media_data.get('Name'),
-                path=media_data.get('Path'),
-                type=media_data.get('Type'),
-                duration=features.get('duration', 0)
+                    """,
+                    media_id=media_data.get("Id"),
+                    name=media_data.get("Name"),
+                    path=media_data.get("Path"),
+                    type=media_data.get("Type"),
+                    duration=features.get("duration", 0),
                 )
 
-                # Create analysis node
                 if analysis_data:
-                    session.run("""
+                    session.run(
+                        """
                         MATCH (m:Media {id: $media_id})
                         MERGE (a:Analysis {media_id: $media_id})
                         SET a.ai_description = $description,
                             a.ai_analysis = $analysis,
+                            a.provider = $provider,
                             a.created_at = datetime()
                         MERGE (m)-[:HAS_ANALYSIS]->(a)
-                    """,
-                    media_id=media_data.get('Id'),
-                    description=analysis_data.get('description', ''),
-                    analysis=json.dumps(analysis_data)
+                        """,
+                        media_id=media_data.get("Id"),
+                        description=analysis_data.get("description", ""),
+                        analysis=json.dumps(analysis_data.get("analysis", analysis_data)),
+                        provider=analysis_data.get("provider", "unknown"),
                     )
 
-                # Create features node
                 if features:
-                    session.run("""
+                    session.run(
+                        """
                         MATCH (m:Media {id: $media_id})
                         MERGE (f:AudioFeatures {media_id: $media_id})
                         SET f += $features,
                             f.created_at = datetime()
                         MERGE (m)-[:HAS_FEATURES]->(f)
-                    """,
-                    media_id=media_data.get('Id'),
-                    features=features
+                        """,
+                        media_id=media_data.get("Id"),
+                        features=features,
                     )
+        except Exception as exc:
+            logger.error("Error storing in Neo4j: %s", exc)
 
-        except Exception as e:
-            logger.error(f"Error storing in Neo4j: {e}")
+    def store_in_supabase(self, media_data: Dict[str, Any], analysis_data: Dict[str, Any], features: Dict[str, Any]) -> None:
+        if not self.supabase:
+            logger.info("Supabase client not configured; skipping Supabase storage.")
+            return
 
-    def store_in_supabase(self, media_data: Dict, analysis_data: Dict, features: Dict):
-        """Store data in Supabase"""
         try:
-            if not self.supabase:
-                return
-
-            # Store in media table
             media_record = {
-                'jellyfin_id': media_data.get('Id'),
-                'name': media_data.get('Name'),
-                'path': media_data.get('Path'),
-                'type': media_data.get('Type'),
-                'duration': features.get('duration', 0),
-                'created_at': 'now()'
+                "jellyfin_id": media_data.get("Id"),
+                "name": media_data.get("Name"),
+                "path": media_data.get("Path"),
+                "type": media_data.get("Type"),
+                "duration": features.get("duration", 0),
+                "created_at": "now()",
             }
-
-            result = self.supabase.table('media').upsert(media_record).execute()
+            result = self.supabase.table("media").upsert(media_record).execute()
 
             if result.data and analysis_data:
-                media_id = result.data[0]['id']
-
-                # Store analysis
+                media_id = result.data[0]["id"]
                 analysis_record = {
-                    'media_id': media_id,
-                    'ai_description': analysis_data.get('description', ''),
-                    'ai_analysis': analysis_data,
-                    'audio_features': features,
-                    'created_at': 'now()'
+                    "media_id": media_id,
+                    "ai_description": analysis_data.get("description", ""),
+                    "ai_analysis": analysis_data.get("analysis", analysis_data),
+                    "audio_features": features,
+                    "provider": analysis_data.get("provider", "unknown"),
+                    "created_at": "now()",
                 }
+                self.supabase.table("media_analysis").insert(analysis_record).execute()
+        except Exception as exc:
+            logger.error("Error storing in Supabase: %s", exc)
 
-                self.supabase.table('media_analysis').insert(analysis_record).execute()
-
-        except Exception as e:
-            logger.error(f"Error storing in Supabase: {e}")
-
-    async def process_media_item(self, item: Dict):
-        """Process a single media item"""
+    async def process_media_item(self, item: Dict[str, Any]) -> None:
         try:
-            media_path = item.get('Path', '')
+            media_path = item.get("Path", "")
             if not media_path or not os.path.exists(media_path):
-                logger.warning(f"Media file not found: {media_path}")
+                logger.warning("Media file not found: %s", media_path)
                 return
 
-            logger.info(f"Processing: {item.get('Name', 'Unknown')}")
-
-            # Check if already processed
-            cache_key = f"processed:{item.get('Id')}"
-            if self.redis_client.get(cache_key):
-                logger.info(f"Already processed: {item.get('Name')}")
+            media_id = item.get("Id")
+            if self._is_processed(media_id):
+                logger.info("Already processed: %s", item.get("Name"))
                 return
 
-            # Extract audio features
+            logger.info("Processing: %s", item.get("Name", "Unknown"))
             features = self.extract_audio_features(media_path)
-
-            # Analyze with AI
-            analysis = await self.analyze_audio_with_qwen(media_path)
-
-            # Store in databases
+            analysis = await self.analyze_audio_with_ai(media_path)
             self.store_in_neo4j(item, analysis, features)
             self.store_in_supabase(item, analysis, features)
+            self._mark_processed(media_id)
+            logger.info("Completed processing: %s", item.get("Name", "Unknown"))
+        except Exception as exc:
+            logger.error("Error processing media item: %s", exc)
 
-            # Mark as processed
-            self.redis_client.setex(cache_key, 86400, "1")  # Cache for 24 hours
-
-            logger.info(f"Completed processing: {item.get('Name')}")
-
-        except Exception as e:
-            logger.error(f"Error processing media item: {e}")
-
-    async def run(self):
-        """Main processing loop"""
-        logger.info("Starting media processor...")
-
+    async def run(self) -> None:
+        logger.info(
+            "Starting media processor with AUDIO_AI_PROVIDER=%s (cross_fallback=%s)",
+            self.audio_provider,
+            self.allow_cross_fallback,
+        )
         while True:
             try:
-                # Get media library from Jellyfin
                 media_items = await self.get_jellyfin_library()
-                logger.info(f"Found {len(media_items)} media items")
-
-                # Process items
+                logger.info("Found %d media items", len(media_items))
                 for item in media_items:
                     await self.process_media_item(item)
-                    await asyncio.sleep(1)  # Rate limiting
+                    await asyncio.sleep(1)
 
-                # Wait before next scan
                 interval = int(os.getenv("PROCESSING_INTERVAL", "300"))
-                logger.info(f"Waiting {interval} seconds before next scan...")
+                logger.info("Waiting %d seconds before next scan...", interval)
                 await asyncio.sleep(interval)
+            except Exception as exc:
+                logger.error("Error in main loop: %s", exc)
+                await asyncio.sleep(60)
 
-            except Exception as e:
-                logger.error(f"Error in main loop: {e}")
-                await asyncio.sleep(60)  # Wait before retrying
+    def shutdown(self) -> None:
+        if self.neo4j_driver:
+            try:
+                self.neo4j_driver.close()
+            except Exception as exc:
+                logger.warning("Neo4j shutdown warning: %s", exc)
+
+        if self.redis_client:
+            try:
+                self.redis_client.close()
+            except Exception as exc:
+                logger.warning("Redis shutdown warning: %s", exc)
+
+
+async def main() -> None:
+    processor = MediaProcessor()
+    try:
+        await processor.run()
+    finally:
+        processor.shutdown()
+
 
 if __name__ == "__main__":
-    processor = MediaProcessor()
-    asyncio.run(processor.run())
+    asyncio.run(main())

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/audio-processor/requirements.txt
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/audio-processor/requirements.txt
@@ -1,7 +1,7 @@
 
 fastapi==0.104.1
 uvicorn==0.24.0
-requests==2.31.0
+requests==2.32.5
 supabase==2.1.0
 neo4j==5.15.0
 redis==5.0.1
@@ -9,10 +9,10 @@ pydub==0.25.1
 librosa==0.10.1
 numpy==1.24.3
 pandas==2.1.4
-python-multipart==0.0.6
+python-multipart>=0.0.26
 python-dotenv==1.0.0
 celery==5.3.4
 sqlalchemy==2.0.23
 asyncpg==0.29.0
-httpx==0.25.2
+httpx==0.24.1
 websockets==12.0

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/audio-processor/tests/test_ai_provider_fallback.py
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/audio-processor/tests/test_ai_provider_fallback.py
@@ -1,0 +1,148 @@
+"""Tests for AI provider fallback logic in the Jellyfin audio processor.
+
+Validates that MediaProcessor correctly falls back between Ollama and
+HuggingFace providers based on availability and cross-fallback settings.
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+if "librosa" not in sys.modules:
+    sys.modules["librosa"] = types.ModuleType("librosa")
+
+if "redis" not in sys.modules:
+    redis_stub = types.ModuleType("redis")
+
+    class _Redis:  # pragma: no cover - stub only
+        def __init__(self, *args, **kwargs):
+            pass
+
+    redis_stub.Redis = _Redis
+    sys.modules["redis"] = redis_stub
+
+if "neo4j" not in sys.modules:
+    neo4j_stub = types.ModuleType("neo4j")
+
+    class _GraphDatabase:  # pragma: no cover - stub only
+        @staticmethod
+        def driver(*args, **kwargs):
+            return None
+
+    neo4j_stub.GraphDatabase = _GraphDatabase
+    sys.modules["neo4j"] = neo4j_stub
+
+if "supabase" not in sys.modules:
+    supabase_stub = types.ModuleType("supabase")
+
+    class _Client:  # pragma: no cover - stub only
+        pass
+
+    def _create_client(*args, **kwargs):  # pragma: no cover - stub only
+        return _Client()
+
+    supabase_stub.Client = _Client
+    supabase_stub.create_client = _create_client
+    sys.modules["supabase"] = supabase_stub
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "main.py"
+SPEC = importlib.util.spec_from_file_location("audio_processor_main", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+def _new_processor(provider: str, allow_cross_fallback: bool = True) -> object:
+    """Create a MediaProcessor configured for a specific provider."""
+    processor = MODULE.MediaProcessor(skip_external_clients=True)
+    processor.audio_provider = provider
+    processor.allow_cross_fallback = allow_cross_fallback
+    return processor
+
+
+def test_auto_falls_back_from_ollama_to_huggingface():
+    """Verify auto mode tries Ollama first, then falls back to HuggingFace."""
+    processor = _new_processor("auto")
+    calls = []
+
+    async def ollama_fail(_audio_path):
+        calls.append("ollama")
+        raise MODULE.AIProviderError("ollama unavailable")
+
+    async def huggingface_ok(_audio_path):
+        calls.append("huggingface")
+        return {"provider": "huggingface", "description": "ok", "analysis": {"text": "ok"}}
+
+    processor._analyze_with_ollama = ollama_fail
+    processor._analyze_with_huggingface = huggingface_ok
+
+    result = asyncio.run(processor.analyze_audio_with_ai("song.wav"))
+    assert result["provider"] == "huggingface"
+    assert calls == ["ollama", "huggingface"]
+
+
+def test_ollama_only_without_cross_fallback():
+    """Verify Ollama-only mode does not fall back when cross-fallback is disabled."""
+    processor = _new_processor("ollama", allow_cross_fallback=False)
+    calls = []
+
+    async def ollama_fail(_audio_path):
+        calls.append("ollama")
+        raise MODULE.AIProviderError("ollama unavailable")
+
+    async def huggingface_ok(_audio_path):
+        calls.append("huggingface")
+        return {"provider": "huggingface", "description": "ok", "analysis": {"text": "ok"}}
+
+    processor._analyze_with_ollama = ollama_fail
+    processor._analyze_with_huggingface = huggingface_ok
+
+    result = asyncio.run(processor.analyze_audio_with_ai("song.wav"))
+    assert result["provider"] == "none"
+    assert calls == ["ollama"]
+
+
+def test_ollama_with_cross_fallback_enabled():
+    """Verify Ollama mode falls back to HuggingFace when cross-fallback is enabled."""
+    processor = _new_processor("ollama", allow_cross_fallback=True)
+    calls = []
+
+    async def ollama_fail(_audio_path):
+        calls.append("ollama")
+        raise MODULE.AIProviderError("ollama unavailable")
+
+    async def huggingface_ok(_audio_path):
+        calls.append("huggingface")
+        return {"provider": "huggingface", "description": "ok", "analysis": {"text": "ok"}}
+
+    processor._analyze_with_ollama = ollama_fail
+    processor._analyze_with_huggingface = huggingface_ok
+
+    result = asyncio.run(processor.analyze_audio_with_ai("song.wav"))
+    assert result["provider"] == "huggingface"
+    assert calls == ["ollama", "huggingface"]
+
+
+def test_huggingface_with_cross_fallback_to_ollama():
+    """Verify HuggingFace mode falls back to Ollama when cross-fallback is enabled."""
+    processor = _new_processor("huggingface", allow_cross_fallback=True)
+    calls = []
+
+    async def huggingface_fail(_audio_path):
+        calls.append("huggingface")
+        raise MODULE.AIProviderError("hf unavailable")
+
+    async def ollama_ok(_audio_path):
+        calls.append("ollama")
+        return {"provider": "ollama", "description": "ok", "analysis": {"text": "ok"}}
+
+    processor._analyze_with_huggingface = huggingface_fail
+    processor._analyze_with_ollama = ollama_ok
+
+    result = asyncio.run(processor.analyze_audio_with_ai("song.wav"))
+    assert result["provider"] == "ollama"
+    assert calls == ["huggingface", "ollama"]

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/dashboard/Dockerfile
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/dashboard/Dockerfile
@@ -16,13 +16,21 @@ COPY . .
 RUN npm run build
 
 # Stage 2: Serve the static files with Nginx
-FROM nginx:1.25-alpine
+# nginx-unprivileged rather than stock nginx + a bare USER directive.
+# Stock nginx binds :80 (privileged) and writes to root-owned /var/cache/nginx
+# and /var/run, so simply adding `USER nginx` produces an image that builds
+# clean and then fails to start. The unprivileged variant is the same nginx
+# built to run as uid 101 on :8080 with writable paths already relocated.
+# NOTE: the port contract changes 80 -> 8080; any compose mapping must follow.
+FROM nginxinc/nginx-unprivileged:1.25-alpine
 
 # Copy the built application from the 'build' stage
 COPY --from=build /app/build /usr/share/nginx/html
 
 # Expose port 80
-EXPOSE 80
+EXPOSE 8080
 
 # Start Nginx
+USER 101
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/dashboard/src/App.css
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/dashboard/src/App.css
@@ -1,21 +1,208 @@
 .App {
-  text-align: center;
+  min-height: 100vh;
+  background: #0f172a;
+  color: #0a0a0a;
 }
 
 .App-header {
-  background-color: #282c34;
-  padding: 20px;
-  color: white;
+  background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+  padding: 24px 32px;
+  color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.App-header h1 {
+  margin: 0;
+  font-size: 1.9rem;
+  font-weight: 600;
 }
 
 .App-main {
-  padding: 20px;
+  padding: 32px;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
-pre {
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.refresh-button {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  padding: 8px 18px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background 0.2s ease;
+}
+
+.refresh-button:disabled {
+  background: #60a5fa;
+  cursor: not-allowed;
+}
+
+.refresh-button:not(:disabled):hover {
+  background: #1d4ed8;
+}
+
+.timestamp {
+  font-size: 0.8rem;
+  color: #e2e8f0;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
   text-align: left;
-  background-color: #f5f5f5;
-  padding: 10px;
-  border-radius: 5px;
-  white-space: pre-wrap;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card.wide {
+  grid-column: 1 / -1;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.3rem;
+  color: #0f172a;
+}
+
+.checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.checklist-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.checklist-item .status {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #94a3b8;
+  flex-shrink: 0;
+  margin-top: 4px;
+}
+
+.checklist-item.completed .status {
+  background: #16a34a;
+  box-shadow: 0 0 0 4px rgba(22, 163, 74, 0.15);
+}
+
+.checklist-item .label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.checklist-item .detail {
+  font-size: 0.85rem;
+  color: #475569;
+  margin-top: 4px;
+}
+
+.latency-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.latency-label {
+  font-size: 0.85rem;
+  color: #64748b;
+  margin-right: 6px;
+}
+
+.latency-value {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.latency-footnote {
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.log-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.log-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.log-panel h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.log-output {
+  background: #0f172a;
+  color: #22c55e;
+  font-family: 'Source Code Pro', 'Fira Code', monospace;
+  padding: 12px;
+  border-radius: 8px;
+  max-height: 280px;
+  overflow-y: auto;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.analytics-pre {
+  background: #f8fafc;
+  padding: 12px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.error {
+  color: #b91c1c;
+  font-weight: 500;
+}
+
+.meta {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+@media (max-width: 768px) {
+  .App-main {
+    padding: 20px;
+  }
+
+  .card {
+    padding: 16px;
+  }
 }

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/dashboard/src/App.js
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/dashboard/src/App.js
@@ -1,41 +1,226 @@
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import './App.css';
 
+const formatMs = (value) => {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) {
+    return '—';
+  }
+  const numeric = Number(value);
+  if (numeric >= 1000) {
+    return `${(numeric / 1000).toFixed(2)} s`;
+  }
+  return `${numeric.toFixed(1)} ms`;
+};
+
+const formatTimestamp = (value) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString();
+};
+
+const LogPanel = ({ title, state }) => (
+  <div className="log-panel">
+    <h3>{title}</h3>
+    {state.loading && <p>Loading…</p>}
+    {state.error && <p className="error">{state.error}</p>}
+    {!state.loading && !state.error && state.entries.length === 0 && (
+      <p>No log entries available.</p>
+    )}
+    {!state.loading && !state.error && state.entries.length > 0 && (
+      <pre className="log-output">{state.entries.join('\n')}</pre>
+    )}
+    {!state.loading && !state.error && state.source && (
+      <p className="meta">Source: {state.source}</p>
+    )}
+  </div>
+);
+
 function App() {
-  const [analytics, setAnalytics] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [analyticsState, setAnalyticsState] = useState({ data: null, loading: true, error: null });
+  const [migrationState, setMigrationState] = useState({ data: null, loading: true, error: null });
+  const [bridgeLogsState, setBridgeLogsState] = useState({ entries: [], source: null, loading: true, error: null });
+  const [publisherLogsState, setPublisherLogsState] = useState({ entries: [], source: null, loading: true, error: null });
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState(null);
+
+  const loadAnalytics = useCallback(async () => {
+    setAnalyticsState((prev) => ({ ...prev, loading: true, error: null }));
+    try {
+      const response = await fetch('/api/analytics');
+      if (!response.ok) {
+        throw new Error('Failed to fetch analytics');
+      }
+      const data = await response.json();
+      setAnalyticsState({ data, loading: false, error: null });
+    } catch (error) {
+      setAnalyticsState({ data: null, loading: false, error: error.message || 'Unable to load analytics' });
+    }
+  }, []);
+
+  const loadMigration = useCallback(async () => {
+    setMigrationState((prev) => ({ ...prev, loading: true, error: null }));
+    try {
+      const response = await fetch('/api/migrations/latest');
+      if (!response.ok) {
+        throw new Error('Failed to fetch migration status');
+      }
+      const data = await response.json();
+      setMigrationState({ data, loading: false, error: null });
+    } catch (error) {
+      setMigrationState({ data: null, loading: false, error: error.message || 'Unable to load migration status' });
+    }
+  }, []);
+
+  const loadBridgeLogs = useCallback(async () => {
+    setBridgeLogsState((prev) => ({ ...prev, loading: true, error: null }));
+    try {
+      const response = await fetch('/api/logs/bridge?lines=120');
+      if (!response.ok) {
+        throw new Error('Failed to fetch bridge logs');
+      }
+      const data = await response.json();
+      setBridgeLogsState({
+        entries: data.entries || [],
+        source: data.source || null,
+        loading: false,
+        error: null
+      });
+    } catch (error) {
+      setBridgeLogsState({ entries: [], source: null, loading: false, error: error.message || 'Unable to load bridge logs' });
+    }
+  }, []);
+
+  const loadPublisherLogs = useCallback(async () => {
+    setPublisherLogsState((prev) => ({ ...prev, loading: true, error: null }));
+    try {
+      const response = await fetch('/api/logs/publisher?lines=120');
+      if (!response.ok) {
+        throw new Error('Failed to fetch publisher logs');
+      }
+      const data = await response.json();
+      setPublisherLogsState({
+        entries: data.entries || [],
+        source: data.source || null,
+        loading: false,
+        error: null
+      });
+    } catch (error) {
+      setPublisherLogsState({ entries: [], source: null, loading: false, error: error.message || 'Unable to load publisher logs' });
+    }
+  }, []);
+
+  const refreshAll = useCallback(async () => {
+    setRefreshing(true);
+    await Promise.allSettled([
+      loadAnalytics(),
+      loadMigration(),
+      loadBridgeLogs(),
+      loadPublisherLogs()
+    ]);
+    setLastUpdated(new Date().toISOString());
+    setRefreshing(false);
+  }, [loadAnalytics, loadMigration, loadBridgeLogs, loadPublisherLogs]);
 
   useEffect(() => {
-    fetch('/api/analytics')
-      .then(response => {
-        if (!response.ok) {
-          throw new Error('Network response was not ok');
-        }
-        return response.json();
-      })
-      .then(data => {
-        setAnalytics(data);
-        setLoading(false);
-      })
-      .catch(error => {
-        setError(error);
-        setLoading(false);
-      });
-  }, []);
+    refreshAll();
+  }, [refreshAll]);
+
+  const checklist = migrationState.data?.checklist || [];
+  const latency = migrationState.data?.webhookLatency || null;
 
   return (
     <div className="App">
       <header className="App-header">
         <h1>Media Analysis Dashboard</h1>
+        <div className="toolbar">
+          <button className="refresh-button" onClick={refreshAll} disabled={refreshing}>
+            {refreshing ? 'Refreshing…' : 'Refresh'}
+          </button>
+          {lastUpdated && (
+            <span className="timestamp">Last updated: {formatTimestamp(lastUpdated)}</span>
+          )}
+        </div>
       </header>
-      <main>
-        <h2>Analytics Data</h2>
-        {loading && <p>Loading...</p>}
-        {error && <p>Error: {error.message}</p>}
-        {analytics && (
-          <pre>{JSON.stringify(analytics, null, 2)}</pre>
-        )}
+      <main className="App-main">
+        <div className="dashboard-grid">
+          <section className="card">
+            <h2>Migration Checklist</h2>
+            {migrationState.loading && <p>Loading…</p>}
+            {migrationState.error && <p className="error">{migrationState.error}</p>}
+            {!migrationState.loading && !migrationState.error && checklist.length === 0 && (
+              <p>No checklist items reported yet.</p>
+            )}
+            {!migrationState.loading && !migrationState.error && checklist.length > 0 && (
+              <ul className="checklist">
+                {checklist.map((item) => (
+                  <li key={item.id} className={`checklist-item ${item.completed ? 'completed' : ''}`}>
+                    <span className="status" aria-hidden="true" />
+                    <div>
+                      <div className="label">{item.label}</div>
+                      {item.detail && <div className="detail">{item.detail}</div>}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="card">
+            <h2>Webhook Latency</h2>
+            {migrationState.loading && <p>Loading…</p>}
+            {migrationState.error && <p className="error">{migrationState.error}</p>}
+            {!migrationState.loading && !migrationState.error && !latency && (
+              <p>No webhook telemetry provided.</p>
+            )}
+            {!migrationState.loading && !migrationState.error && latency && (
+              <div className="latency-metric">
+                <div>
+                  <span className="latency-label">Average</span>
+                  <span className="latency-value">{formatMs(latency.averageMs ?? latency.avgMs ?? latency.meanMs)}</span>
+                </div>
+                {(latency.p95Ms || latency.p95) && (
+                  <div>
+                    <span className="latency-label">p95</span>
+                    <span className="latency-value">{formatMs(latency.p95Ms ?? latency.p95)}</span>
+                  </div>
+                )}
+                {(latency.p99Ms || latency.p99) && (
+                  <div>
+                    <span className="latency-label">p99</span>
+                    <span className="latency-value">{formatMs(latency.p99Ms ?? latency.p99)}</span>
+                  </div>
+                )}
+                {(latency.sampleSize || latency.samples || latency.count) && (
+                  <div className="latency-footnote">Sample size: {latency.sampleSize ?? latency.samples ?? latency.count}</div>
+                )}
+                {latency.lastEventAt && (
+                  <div className="latency-footnote">Last webhook: {formatTimestamp(latency.lastEventAt)}</div>
+                )}
+              </div>
+            )}
+          </section>
+
+          <section className="card wide">
+            <h2>Log Viewer</h2>
+            <div className="log-grid">
+              <LogPanel title="Jellyfin Bridge" state={bridgeLogsState} />
+              <LogPanel title="Publisher" state={publisherLogsState} />
+            </div>
+          </section>
+
+          <section className="card wide">
+            <h2>Analytics Snapshot</h2>
+            {analyticsState.loading && <p>Loading…</p>}
+            {analyticsState.error && <p className="error">{analyticsState.error}</p>}
+            {!analyticsState.loading && !analyticsState.error && analyticsState.data && (
+              <pre className="analytics-pre">{JSON.stringify(analyticsState.data, null, 2)}</pre>
+            )}
+            {!analyticsState.loading && !analyticsState.error && !analyticsState.data && (
+              <p>No analytics data reported.</p>
+            )}
+          </section>
+        </div>
       </main>
     </div>
   );

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/dashboard/src/index.js
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/dashboard/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './App.css';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/docker-compose.yml
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/docker-compose.yml
@@ -2,16 +2,21 @@
 version: '3.8'
 
 networks:
+
   media-stack:
     driver: bridge
+
+  media-stack:
+    driver: bridge
+
   supabase-network:
     external: true
-    name: supabase_default
+    name: pmoves-net
 
 services:
   # Jellyfin Media Server
   jellyfin:
-    image: lscr.io/linuxserver/jellyfin:latest
+    image: lscr.io/linuxserver/jellyfin:10.11.0
     container_name: jellyfin
     environment:
       - PUID=1000
@@ -109,11 +114,25 @@ services:
       context: ./audio-processor
       dockerfile: Dockerfile
     container_name: audio-processor
+
     environment:
       - JELLYFIN_URL=http://jellyfin:8096
+      - JELLYFIN_USERNAME=${JELLYFIN_USERNAME}
+      - JELLYFIN_PASSWORD=${JELLYFIN_PASSWORD}
+      - JELLYFIN_API_KEY=${JELLYFIN_API_KEY}
       - SUPABASE_URL=${SUPABASE_URL}
       - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
       - NEO4J_URI=bolt://neo4j:7687
+
+    environment:
+      - JELLYFIN_URL=http://jellyfin:8096
+      - JELLYFIN_USERNAME=${JELLYFIN_USERNAME}
+      - JELLYFIN_PASSWORD=${JELLYFIN_PASSWORD}
+      - JELLYFIN_API_KEY=${JELLYFIN_API_KEY}
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+      - NEO4J_URI=bolt://neo4j:7687
+
       - NEO4J_USER=neo4j
       - NEO4J_PASSWORD=mediapassword123
       - QWEN_AUDIO_URL=http://qwen-audio:8000

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/docker-compose.yml
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/docker-compose.yml
@@ -6,9 +6,6 @@ networks:
   media-stack:
     driver: bridge
 
-  media-stack:
-    driver: bridge
-
   supabase-network:
     external: true
     name: pmoves-net
@@ -123,20 +120,17 @@ services:
       - SUPABASE_URL=${SUPABASE_URL}
       - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
       - NEO4J_URI=bolt://neo4j:7687
-
-    environment:
-      - JELLYFIN_URL=http://jellyfin:8096
-      - JELLYFIN_USERNAME=${JELLYFIN_USERNAME}
-      - JELLYFIN_PASSWORD=${JELLYFIN_PASSWORD}
-      - JELLYFIN_API_KEY=${JELLYFIN_API_KEY}
-      - SUPABASE_URL=${SUPABASE_URL}
-      - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
-      - NEO4J_URI=bolt://neo4j:7687
-
       - NEO4J_USER=neo4j
       - NEO4J_PASSWORD=mediapassword123
       - QWEN_AUDIO_URL=http://qwen-audio:8000
       - PROCESSING_INTERVAL=300  # Process every 5 minutes
+      # This stack names the cache service `redis`; main.py defaults REDIS_HOST
+      # to `jellyfin-redis`, which is the service name in PMOVES.AI's
+      # docker-compose.jellyfin-ai.yml. Set it explicitly here rather than
+      # changing that default: PMOVES supplies no REDIS_HOST and relies on it,
+      # so retargeting the default would fix this stack and silently disable
+      # caching in the PMOVES deployment.
+      - REDIS_HOST=redis
     volumes:
       - ./media:/app/media
       - ./output:/app/output
@@ -200,7 +194,11 @@ services:
       - REACT_APP_JELLYFIN_URL=http://localhost:8096
       - REACT_APP_NEO4J_URL=http://localhost:7474
     ports:
-      - "3001:80"
+      # 8080, not 80: this image is nginxinc/nginx-unprivileged, which cannot
+      # bind the privileged port and listens on 8080 (dashboard/Dockerfile
+      # EXPOSE 8080). Publishing to :80 targeted a port nothing listens on, so
+      # the container came up healthy and the dashboard was unreachable.
+      - "3001:8080"
     networks:
       - media-stack
     restart: unless-stopped

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/jellyfin-ai-media-stack-guide.md
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/jellyfin-ai-media-stack-guide.md
@@ -143,12 +143,14 @@ The provisioning bundle ships with `scripts/jellyfin_backup.sh`, a helper that w
 **Manual backup**
 
 ```bash
-cd CATACLYSM_STUDIOS_INC/PMOVES-PROVISIONS/docker-stacks/jellyfin-ai
+cd Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai
 scripts/jellyfin_backup.sh backup \
   --stack-root /path/to/docker-stacks/jellyfin-ai \
-  --bundle-dir /path/to/docker-stacks/jellyfin-ai/backups \
-  --upload
+  --bundle-dir /path/to/docker-stacks/jellyfin-ai/backups
 ```
+
+Uploading is the default. The script accepts `--no-upload` to suppress it; there
+is no `--upload` flag, and passing one exits with `Unknown option: --upload`.
 
 * Authenticates with `JELLYFIN_API_KEY` or the username/password pair defined in `.env`.
 * Persists the generated archive under `<stack-root>/backups/` alongside the provisioning bundle.

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/scripts/jellyfin_backup.sh
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/scripts/jellyfin_backup.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+# jellyfin_backup.sh - Jellyfin 10.11 backup/restore helper for PMOVES provisioning bundles
+set -u
+set -o pipefail
+
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+SCRIPT_DIR=$(cd "$(dirname "${SCRIPT_PATH}")" && pwd)
+STACK_ROOT_DEFAULT=$(cd "${SCRIPT_DIR}/.." && pwd)
+STACK_ROOT=${JELLYFIN_STACK_ROOT:-${STACK_ROOT_DEFAULT}}
+ARCHIVE_DIR_DEFAULT="${STACK_ROOT}/backups"
+ARCHIVE_DIR="${JELLYFIN_ARCHIVE_DIR:-${ARCHIVE_DIR_DEFAULT}}"
+JELLYFIN_URL=${JELLYFIN_URL:-"http://localhost:8096"}
+CURL_BIN=${CURL_BIN:-curl}
+JQ_BIN=${JQ_BIN:-jq}
+UPLOAD_TO_SUPABASE=1
+SUPABASE_BUCKET=${SUPABASE_JELLYFIN_BACKUP_BUCKET:-"jellyfin-backups"}
+SUPABASE_PREFIX=${SUPABASE_JELLYFIN_BACKUP_PREFIX:-"archives"}
+BACKUP_PAYLOAD='{"Metadata":true,"Trickplay":true,"Subtitles":true,"Database":true}'
+AUTH_TOKEN=""
+CLIENT_HEADER="MediaBrowser Client=\"pmoves-backup\", Device=\"PMOVES Provisioning\", DeviceId=\"pmoves-provisioning\", Version=\"1.0.0\""
+JELLYFIN_CONFIG_PATH=${JELLYFIN_CONFIG_PATH:-"${STACK_ROOT}/jellyfin/config"}
+JELLYFIN_CACHE_PATH=${JELLYFIN_CACHE_PATH:-"${STACK_ROOT}/jellyfin/cache"}
+
+log() {
+  echo "[jellyfin-backup] $*" >&2
+}
+
+warn() {
+  log "WARN: $*"
+}
+
+err() {
+  log "ERROR: $*" >&2
+}
+
+usage() {
+  cat <<USAGE
+Usage: ${0##*/} <command> [options]
+
+Commands:
+  backup            Trigger a Jellyfin backup, copy the archive into the provisioning bundle, and optionally upload to Supabase.
+  restore           Copy an archive into Jellyfin's backup directory and invoke the restore endpoint.
+
+Options (apply to both commands):
+  --stack-root PATH       Override the Jellyfin stack root (default: ${STACK_ROOT_DEFAULT}).
+  --bundle-dir PATH       Override the archive output directory (default: <stack-root>/backups).
+  --config-dir PATH       Override host path mapped to /config (default: <stack-root>/jellyfin/config).
+  --cache-dir PATH        Override host path mapped to /cache (default: <stack-root>/jellyfin/cache).
+  --supabase-bucket NAME  Override Supabase bucket (default: ${SUPABASE_BUCKET}).
+  --supabase-prefix PATH  Override Supabase prefix (default: ${SUPABASE_PREFIX}).
+  --no-upload             Skip Supabase upload even if secrets are present.
+  -h, --help              Show this help message.
+
+Restore command options:
+  --archive PATH          Archive to restore (local path inside provisioning bundle).
+
+Environment fallbacks:
+  JELLYFIN_URL, JELLYFIN_API_KEY, JELLYFIN_USERNAME, JELLYFIN_PASSWORD,
+  SUPABASE_URL, SUPABASE_SERVICE_KEY, SUPABASE_JELLYFIN_BACKUP_BUCKET,
+  SUPABASE_JELLYFIN_BACKUP_PREFIX, JELLYFIN_STACK_ROOT, JELLYFIN_ARCHIVE_DIR,
+  JELLYFIN_CONFIG_PATH, JELLYFIN_CACHE_PATH.
+USAGE
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    err "Required command '$1' not found in PATH."
+    exit 1
+  fi
+}
+
+sanitize_bucket_path() {
+  local value="$1"
+  value="${value#/}"
+  echo "${value%/}"
+}
+
+load_env_file() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    if [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+      local key="${line%%=*}"
+      local value="${line#*=}"
+      value="${value%$'\r'}"
+      value="${value#\"}"
+      value="${value%\"}"
+      value="${value#\'}"
+      value="${value%\'}"
+      export "$key=$value"
+    fi
+  done < "$file"
+}
+
+load_stack_env() {
+  local root="$1"
+  load_env_file "${root}/.env"
+  load_env_file "${root}/.env.local"
+}
+
+resolve_host_path() {
+  local candidate="$1"
+  if [[ -f "$candidate" ]]; then
+    echo "$candidate"
+    return 0
+  fi
+  if [[ "$candidate" == /config/* ]]; then
+    local suffix="${candidate#/config/}"
+    local host_path="${JELLYFIN_CONFIG_PATH}/${suffix}"
+    if [[ -f "$host_path" ]]; then
+      echo "$host_path"
+      return 0
+    fi
+  fi
+  if [[ "$candidate" == /cache/* ]]; then
+    local suffix="${candidate#/cache/}"
+    local host_path="${JELLYFIN_CACHE_PATH}/${suffix}"
+    if [[ -f "$host_path" ]]; then
+      echo "$host_path"
+      return 0
+    fi
+  fi
+  echo "$candidate"
+}
+
+jellyfin_ping() {
+  ${CURL_BIN} -sS --max-time 5 "${JELLYFIN_URL%/}/System/Ping" >/dev/null
+}
+
+get_auth_token() {
+  if [[ -n "${JELLYFIN_API_KEY:-}" ]]; then
+    AUTH_TOKEN="${JELLYFIN_API_KEY}"
+    return 0
+  fi
+  if [[ -n "${JELLYFIN_USERNAME:-}" && -n "${JELLYFIN_PASSWORD:-}" ]]; then
+    local response
+    response=$(${CURL_BIN} -sS --fail \
+      -H "Content-Type: application/json" \
+      -H "X-Emby-Authorization: ${CLIENT_HEADER}" \
+      -X POST "${JELLYFIN_URL%/}/Users/AuthenticateByName" \
+      -d "{\"Username\":\"${JELLYFIN_USERNAME}\",\"Pw\":\"${JELLYFIN_PASSWORD}\"}" 2>/dev/null) || return 1
+    AUTH_TOKEN=$(printf '%s' "$response" | ${JQ_BIN} -r '.AccessToken' 2>/dev/null)
+    if [[ -n "$AUTH_TOKEN" && "$AUTH_TOKEN" != null ]]; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+call_jellyfin_api() {
+  local method="$1"
+  local path="$2"
+  shift 2
+  local headers=("-H" "X-Emby-Authorization: ${CLIENT_HEADER}")
+  if [[ -n "$AUTH_TOKEN" ]]; then
+    headers+=("-H" "X-Emby-Token: ${AUTH_TOKEN}")
+  fi
+  ${CURL_BIN} -sS --fail -X "$method" "${JELLYFIN_URL%/}${path}" "${headers[@]}" "$@"
+}
+
+perform_backup() {
+  if ! jellyfin_ping; then
+    warn "Jellyfin is unreachable at ${JELLYFIN_URL}; skipping backup."
+    return 0
+  fi
+  if ! get_auth_token; then
+    warn "Unable to obtain Jellyfin token (set JELLYFIN_API_KEY or username/password)."
+    return 1
+  fi
+  local response
+  response=$(call_jellyfin_api POST "/Backup/Create" -H "Content-Type: application/json" -d "${BACKUP_PAYLOAD}") || return 1
+  local manifest_path
+  manifest_path=$(printf '%s' "$response" | ${JQ_BIN} -r '.Path')
+  if [[ -z "$manifest_path" || "$manifest_path" == null ]]; then
+    err "Backup manifest did not include archive path."
+    return 1
+  fi
+  local resolved
+  resolved=$(resolve_host_path "$manifest_path")
+  if [[ ! -f "$resolved" ]]; then
+    err "Backup archive ${resolved} not found on host."
+    return 1
+  fi
+  mkdir -p "$ARCHIVE_DIR"
+  local archive_name
+  archive_name=$(basename "$manifest_path")
+  local dest="${ARCHIVE_DIR}/${archive_name}"
+  cp "$resolved" "$dest"
+  log "Backup stored at ${dest}."
+  if (( UPLOAD_TO_SUPABASE )); then
+    upload_to_supabase "$dest"
+  else
+    log "Supabase upload disabled (--no-upload)."
+  fi
+}
+
+supabase_ready() {
+  [[ -n "${SUPABASE_URL:-}" && -n "${SUPABASE_SERVICE_KEY:-}" ]]
+}
+
+upload_to_supabase() {
+  local file="$1"
+  if ! supabase_ready; then
+    warn "Supabase secrets missing; skipping upload."
+    return 0
+  fi
+  local bucket
+  bucket=$(sanitize_bucket_path "${SUPABASE_BUCKET}")
+  local prefix
+  prefix=$(sanitize_bucket_path "${SUPABASE_PREFIX}")
+  local object_name
+  object_name=$(basename "$file")
+  local storage_path
+  if [[ -n "$prefix" ]]; then
+    storage_path="${prefix}/${object_name}"
+  else
+    storage_path="$object_name"
+  fi
+  local url="${SUPABASE_URL%/}/storage/v1/object/${bucket}/${storage_path}"
+  if ${CURL_BIN} -sS --fail -X POST "$url" \
+      -H "Authorization: Bearer ${SUPABASE_SERVICE_KEY}" \
+      -H "apikey: ${SUPABASE_SERVICE_KEY}" \
+      -H "Content-Type: application/zip" \
+      -H "x-upsert: true" \
+      --data-binary @"${file}" >/dev/null; then
+    log "Uploaded ${object_name} to Supabase bucket ${bucket}/${storage_path}."
+  else
+    warn "Failed to upload ${object_name} to Supabase."
+    return 1
+  fi
+}
+
+perform_restore() {
+  local archive="$1"
+  if [[ -z "$archive" ]]; then
+    err "Restore requires --archive <path>."
+    return 1
+  fi
+  if [[ ! -f "$archive" ]]; then
+    err "Archive ${archive} not found."
+    return 1
+  fi
+  if ! jellyfin_ping; then
+    err "Jellyfin is unreachable at ${JELLYFIN_URL}; cannot restore."
+    return 1
+  fi
+  if ! get_auth_token; then
+    err "Unable to obtain Jellyfin token for restore."
+    return 1
+  fi
+  local existing_list
+  existing_list=$(call_jellyfin_api GET "/Backup" || true)
+  local target_dir=""
+  if [[ -n "$existing_list" ]]; then
+    target_dir=$(printf '%s' "$existing_list" | ${JQ_BIN} -r '.[0].Path | select(.!=null) | split("/")[:-1] | join("/")')
+  fi
+  if [[ -z "$target_dir" ]]; then
+    target_dir="${JELLYFIN_CONFIG_PATH}/data/backups"
+    [[ -d "$target_dir" ]] || target_dir="${JELLYFIN_CONFIG_PATH}/backups"
+  fi
+  mkdir -p "$target_dir"
+  local filename
+  filename=$(basename "$archive")
+  cp "$archive" "${target_dir}/${filename}"
+  log "Copied ${archive} into ${target_dir}."
+  if call_jellyfin_api POST "/Backup/Restore" -H "Content-Type: application/json" -d "{\"ArchiveFileName\":\"${filename}\"}" >/dev/null; then
+    log "Restore scheduled for ${filename}. Jellyfin will restart to apply backup."
+  else
+    err "Failed to invoke restore endpoint."
+    return 1
+  fi
+}
+
+COMMAND=""
+ARCHIVE_ARG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    backup|restore)
+      COMMAND="$1"
+      shift
+      break
+      ;;
+    --stack-root)
+      STACK_ROOT="$2"
+      shift 2
+      ;;
+    --bundle-dir)
+      ARCHIVE_DIR="$2"
+      shift 2
+      ;;
+    --config-dir)
+      JELLYFIN_CONFIG_PATH="$2"
+      shift 2
+      ;;
+    --cache-dir)
+      JELLYFIN_CACHE_PATH="$2"
+      shift 2
+      ;;
+    --supabase-bucket)
+      SUPABASE_BUCKET="$2"
+      shift 2
+      ;;
+    --supabase-prefix)
+      SUPABASE_PREFIX="$2"
+      shift 2
+      ;;
+    --no-upload)
+      UPLOAD_TO_SUPABASE=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      err "Unknown option: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$COMMAND" ]]; then
+  usage
+  exit 1
+fi
+
+case "$COMMAND" in
+  backup)
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --stack-root)
+          STACK_ROOT="$2"; shift 2 ;;
+        --bundle-dir)
+          ARCHIVE_DIR="$2"; shift 2 ;;
+        --config-dir)
+          JELLYFIN_CONFIG_PATH="$2"; shift 2 ;;
+        --cache-dir)
+          JELLYFIN_CACHE_PATH="$2"; shift 2 ;;
+        --supabase-bucket)
+          SUPABASE_BUCKET="$2"; shift 2 ;;
+        --supabase-prefix)
+          SUPABASE_PREFIX="$2"; shift 2 ;;
+        --no-upload)
+          UPLOAD_TO_SUPABASE=0; shift ;;
+        -h|--help)
+          usage; exit 0 ;;
+        *)
+          err "Unknown option for backup: $1"
+          usage
+          exit 1
+          ;;
+      esac
+    done
+    ;;
+  restore)
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --archive)
+          ARCHIVE_ARG="$2"; shift 2 ;;
+        --stack-root)
+          STACK_ROOT="$2"; shift 2 ;;
+        --bundle-dir)
+          ARCHIVE_DIR="$2"; shift 2 ;;
+        --config-dir)
+          JELLYFIN_CONFIG_PATH="$2"; shift 2 ;;
+        --cache-dir)
+          JELLYFIN_CACHE_PATH="$2"; shift 2 ;;
+        --supabase-bucket)
+          SUPABASE_BUCKET="$2"; shift 2 ;;
+        --supabase-prefix)
+          SUPABASE_PREFIX="$2"; shift 2 ;;
+        --no-upload)
+          UPLOAD_TO_SUPABASE=0; shift ;;
+        -h|--help)
+          usage; exit 0 ;;
+        *)
+          err "Unknown option for restore: $1"
+          usage
+          exit 1
+          ;;
+      esac
+    done
+    ;;
+esac
+
+require_command "$CURL_BIN"
+require_command "$JQ_BIN"
+mkdir -p "$ARCHIVE_DIR"
+load_stack_env "$STACK_ROOT"
+SUPABASE_BUCKET=$(sanitize_bucket_path "$SUPABASE_BUCKET")
+SUPABASE_PREFIX=$(sanitize_bucket_path "$SUPABASE_PREFIX")
+
+case "$COMMAND" in
+  backup)
+    perform_backup
+    ;;
+  restore)
+    perform_restore "$ARCHIVE_ARG"
+    ;;
+esac

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/scripts/jellyfin_backup.sh
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/scripts/jellyfin_backup.sh
@@ -7,6 +7,13 @@ SCRIPT_PATH="${BASH_SOURCE[0]}"
 SCRIPT_DIR=$(cd "$(dirname "${SCRIPT_PATH}")" && pwd)
 STACK_ROOT_DEFAULT=$(cd "${SCRIPT_DIR}/.." && pwd)
 STACK_ROOT=${JELLYFIN_STACK_ROOT:-${STACK_ROOT_DEFAULT}}
+# Capture explicitness BEFORE the defaults below overwrite these names.
+# --stack-root is parsed after this file is sourced, so anything derived from
+# STACK_ROOT here is derived from the OLD root; rederive_stack_paths() fixes
+# that afterwards, but must not clobber a value the operator set on purpose.
+ARCHIVE_DIR_EXPLICIT=${JELLYFIN_ARCHIVE_DIR:+1}
+JELLYFIN_CONFIG_PATH_EXPLICIT=${JELLYFIN_CONFIG_PATH:+1}
+JELLYFIN_CACHE_PATH_EXPLICIT=${JELLYFIN_CACHE_PATH:+1}
 ARCHIVE_DIR_DEFAULT="${STACK_ROOT}/backups"
 ARCHIVE_DIR="${JELLYFIN_ARCHIVE_DIR:-${ARCHIVE_DIR_DEFAULT}}"
 JELLYFIN_URL=${JELLYFIN_URL:-"http://localhost:8096"}
@@ -20,6 +27,24 @@ AUTH_TOKEN=""
 CLIENT_HEADER="MediaBrowser Client=\"pmoves-backup\", Device=\"PMOVES Provisioning\", DeviceId=\"pmoves-provisioning\", Version=\"1.0.0\""
 JELLYFIN_CONFIG_PATH=${JELLYFIN_CONFIG_PATH:-"${STACK_ROOT}/jellyfin/config"}
 JELLYFIN_CACHE_PATH=${JELLYFIN_CACHE_PATH:-"${STACK_ROOT}/jellyfin/cache"}
+
+# Re-derive anything that hangs off STACK_ROOT, after argument parsing.
+#
+# --stack-root is documented as a post-command flag, but ARCHIVE_DIR,
+# JELLYFIN_CONFIG_PATH and JELLYFIN_CACHE_PATH are all computed above from the
+# script's own location. Overriding the root therefore moved STACK_ROOT and
+# nothing else, so backups and restores kept reading and writing under the
+# original tree -- silently, and only for the paths the operator did not also
+# pass by hand.
+#
+# Values set explicitly (env at load, or a --flag during parsing) are left
+# alone; only the implicit ones follow the root.
+rederive_stack_paths() {
+  [[ -z "${ARCHIVE_DIR_EXPLICIT:-}" ]] && ARCHIVE_DIR="${STACK_ROOT}/backups"
+  [[ -z "${JELLYFIN_CONFIG_PATH_EXPLICIT:-}" ]] && JELLYFIN_CONFIG_PATH="${STACK_ROOT}/jellyfin/config"
+  [[ -z "${JELLYFIN_CACHE_PATH_EXPLICIT:-}" ]] && JELLYFIN_CACHE_PATH="${STACK_ROOT}/jellyfin/cache"
+  return 0
+}
 
 log() {
   echo "[jellyfin-backup] $*" >&2
@@ -122,6 +147,26 @@ resolve_host_path() {
       return 0
     fi
   fi
+  echo "$candidate"
+}
+
+resolve_host_dir() {
+  # Directory counterpart of resolve_host_path.
+  #
+  # Jellyfin reports paths as the CONTAINER sees them (/config/..., /cache/...).
+  # Restore derives its target directory from the API and previously used that
+  # value as a host path, so it copied the archive to /config/... ON THE HOST --
+  # or failed on permissions -- instead of into the mapped volume.
+  #
+  # Prefix-map rather than probing with -d: /config can exist on the host for
+  # unrelated reasons, and a successful probe there would be the wrong answer.
+  local candidate="$1"
+  case "$candidate" in
+    /config)   echo "${JELLYFIN_CONFIG_PATH}" ; return 0 ;;
+    /config/*) echo "${JELLYFIN_CONFIG_PATH}/${candidate#/config/}" ; return 0 ;;
+    /cache)    echo "${JELLYFIN_CACHE_PATH}" ; return 0 ;;
+    /cache/*)  echo "${JELLYFIN_CACHE_PATH}/${candidate#/cache/}" ; return 0 ;;
+  esac
   echo "$candidate"
 }
 
@@ -255,6 +300,9 @@ perform_restore() {
   local target_dir=""
   if [[ -n "$existing_list" ]]; then
     target_dir=$(printf '%s' "$existing_list" | ${JQ_BIN} -r '.[0].Path | select(.!=null) | split("/")[:-1] | join("/")')
+    # The API answers with a container path; the fallback below already uses the
+    # host-side JELLYFIN_CONFIG_PATH, so translate to match it.
+    [[ -n "$target_dir" ]] && target_dir=$(resolve_host_dir "$target_dir")
   fi
   if [[ -z "$target_dir" ]]; then
     target_dir="${JELLYFIN_CONFIG_PATH}/data/backups"
@@ -287,15 +335,15 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --bundle-dir)
-      ARCHIVE_DIR="$2"
+      ARCHIVE_DIR="$2"; ARCHIVE_DIR_EXPLICIT=1
       shift 2
       ;;
     --config-dir)
-      JELLYFIN_CONFIG_PATH="$2"
+      JELLYFIN_CONFIG_PATH="$2"; JELLYFIN_CONFIG_PATH_EXPLICIT=1
       shift 2
       ;;
     --cache-dir)
-      JELLYFIN_CACHE_PATH="$2"
+      JELLYFIN_CACHE_PATH="$2"; JELLYFIN_CACHE_PATH_EXPLICIT=1
       shift 2
       ;;
     --supabase-bucket)
@@ -321,6 +369,7 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+rederive_stack_paths
 
 if [[ -z "$COMMAND" ]]; then
   usage
@@ -334,11 +383,11 @@ case "$COMMAND" in
         --stack-root)
           STACK_ROOT="$2"; shift 2 ;;
         --bundle-dir)
-          ARCHIVE_DIR="$2"; shift 2 ;;
+          ARCHIVE_DIR="$2"; ARCHIVE_DIR_EXPLICIT=1; shift 2 ;;
         --config-dir)
-          JELLYFIN_CONFIG_PATH="$2"; shift 2 ;;
+          JELLYFIN_CONFIG_PATH="$2"; JELLYFIN_CONFIG_PATH_EXPLICIT=1; shift 2 ;;
         --cache-dir)
-          JELLYFIN_CACHE_PATH="$2"; shift 2 ;;
+          JELLYFIN_CACHE_PATH="$2"; JELLYFIN_CACHE_PATH_EXPLICIT=1; shift 2 ;;
         --supabase-bucket)
           SUPABASE_BUCKET="$2"; shift 2 ;;
         --supabase-prefix)
@@ -354,6 +403,7 @@ case "$COMMAND" in
           ;;
       esac
     done
+    rederive_stack_paths
     ;;
   restore)
     while [[ $# -gt 0 ]]; do
@@ -363,11 +413,11 @@ case "$COMMAND" in
         --stack-root)
           STACK_ROOT="$2"; shift 2 ;;
         --bundle-dir)
-          ARCHIVE_DIR="$2"; shift 2 ;;
+          ARCHIVE_DIR="$2"; ARCHIVE_DIR_EXPLICIT=1; shift 2 ;;
         --config-dir)
-          JELLYFIN_CONFIG_PATH="$2"; shift 2 ;;
+          JELLYFIN_CONFIG_PATH="$2"; JELLYFIN_CONFIG_PATH_EXPLICIT=1; shift 2 ;;
         --cache-dir)
-          JELLYFIN_CACHE_PATH="$2"; shift 2 ;;
+          JELLYFIN_CACHE_PATH="$2"; JELLYFIN_CACHE_PATH_EXPLICIT=1; shift 2 ;;
         --supabase-bucket)
           SUPABASE_BUCKET="$2"; shift 2 ;;
         --supabase-prefix)
@@ -383,6 +433,7 @@ case "$COMMAND" in
           ;;
       esac
     done
+    rederive_stack_paths
     ;;
 esac
 

--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/setup.sh
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/setup.sh
@@ -34,6 +34,7 @@ if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/
     exit 1
 fi
 
+
 # Create necessary directories
 print_status "Creating directory structure..."
 mkdir -p media/{music,videos,podcasts}
@@ -44,10 +45,37 @@ mkdir -p output
 mkdir -p logs
 mkdir -p redis/data
 
+# Create necessary directories
+print_status "Creating directory structure..."
+mkdir -p media/{music,videos,podcasts}
+mkdir -p jellyfin/{config,cache}
+mkdir -p neo4j/{data,logs,import,plugins}
+mkdir -p qwen/{models,cache}
+mkdir -p output
+mkdir -p logs
+mkdir -p redis/data
+
+# Ensure the shared pmoves-net network exists for Supabase connectivity
+if ! docker network ls --format '{{.Name}}' | grep -wq "pmoves-net"; then
+    print_status "Creating shared pmoves-net network..."
+    docker network create pmoves-net
+else
+    print_status "Using existing pmoves-net network"
+fi
+
+
 # Set permissions
 print_status "Setting directory permissions..."
 sudo chown -R $USER:$USER jellyfin/ neo4j/ qwen/ output/ logs/ redis/
 chmod -R 755 jellyfin/ neo4j/ qwen/ output/ logs/ redis/
+
+# Ensure shared Docker network exists for Supabase connectivity
+if ! docker network inspect pmoves-net >/dev/null 2>&1; then
+    print_status "Creating shared pmoves-net network..."
+    docker network create pmoves-net
+else
+    print_status "Using existing pmoves-net network"
+fi
 
 # Create environment file if it doesn't exist
 if [ ! -f .env ]; then


### PR DESCRIPTION
This fork is meant to be the source of truth for the Jellyfin AI stack. The parent repo's `CATACLYSM_STUDIOS_INC/L4-PLATFORM/provisions/docker-stacks/jellyfin-ai/` is where this code lived **before the submodule existed**, and the parent's compose still builds from that copy.

Repointing those build contexts here was the obvious next step — and would have been wrong.

## The parent copy is AHEAD, not behind

**26 files vs 22 here. 23 differences.** It carries things this fork never had:

| | |
|---|---|
| `api-gateway/package-lock.json` | a lockfile |
| `audio-processor/tests/` | a test suite |
| `audio-processor/Dockerfile` | **27 → 65 lines** — multi-stage `ffmpeg-downloader`, `FFMPEG_VERSION` pinned to 7.1, `--no-install-recommends`, apt cleanup |

And most importantly, **the de-hardcoding work**. This fork's `audio-processor` is Qwen-only:

```yaml
image: qwen/qwen-audio:latest
MODEL_NAME: Qwen/Qwen-Audio-Chat
```

The parent's version reads `AUDIO_AI_PROVIDER` and supports **three** backends — Qwen, Ollama and HuggingFace — each with its own URL and model env var, plus **cross-provider fallback with tests** (`test_auto_falls_back_from_ollama_to_huggingface`).

A straight repoint would have silently reverted all of it. So the fork absorbs the drift first; only then can the parent build from here without losing work.

## Hardening

Neither copy had a `USER` directive. All three parent paths sit in the ratchet's `_known_gaps.yaml` baseline, whose own header says those entries are **NOT approved**. Fixed here so the parent can retire them when it repoints:

- **audio-processor** — uid/gid **65532** (the fleet convention from `services/agent-zero` and `services/gateway-agent`); ownership set explicitly rather than by a late recursive `chown`
- **api-gateway** — same 65532 pinning. Alpine's unused uid 1000 `node` is deliberately *not* reused, so compose `user:` overrides stay uniform fleet-wide
- **dashboard** — switched to `nginxinc/nginx-unprivileged`. Adding a bare `USER nginx` to stock nginx produces an image that **builds clean and then fails to start**: `:80` is privileged and `/var/cache/nginx` and `/var/run` are root-owned. The unprivileged variant is the same nginx already built to run as uid 101 on `:8080` with the writable paths relocated.

## ⚠️ Breaking

**The dashboard port contract changes 80 → 8080.** Any compose mapping must follow — the parent currently maps `3001:80`.

## Verification

Replicated `hardening_ratchet`'s three rules (`NO_FROM`, `NO_USER`, `ROOT_USER` judged on the **last** `USER` directive) against all three files:

```
audio-processor    OK (last USER = pmoves)
api-gateway        OK (last USER = pmoves)
dashboard          OK (last USER = 101)
```

## Next (parent repo)

1. Repoint `docker-compose.jellyfin-ai.yml` build contexts at this submodule
2. Fix the `3001:80` → `3001:8080` mapping
3. Retire `provisions/docker-stacks/jellyfin-ai/` and drop the three `_known_gaps.yaml` entries
4. Pin `ollama/ollama:latest`