### PR TITLE
fix(dashboard): build under floating eslint 9 — disable the CRA lint plugin

### DIFF
--- a/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/dashboard/package.json
+++ b/Cataclysm_Provisioning_Bundle/provisioning_bundle/docker-stacks/jellyfin-ai/dashboard/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "DISABLE_ESLINT_PLUGIN=true react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
## Summary
The dashboard image cannot build at all: `react-scripts 5.0.1` with **no committed lockfile** floats eslint to 9.x, and `eslint-config-react-app/jest` dies on `Environment key "jest/globals" is unknown` before webpack runs.

An `npm overrides: {eslint: 8.x}` pin does **not** fix it — verified on the build host (overrides don't repair the transitive eslint-config-react-app resolution).

`DISABLE_ESLINT_PLUGIN=true` is the react-scripts-sanctioned escape: CRA's webpack config reads it and skips the eslint-webpack-plugin entirely. Build-time lint on a static dashboard is not load-bearing; a reproducible image is.

## Testing (arm64 / GB10 SPARK)
- Image builds (was failing)
- Container starts as uid 101 (nginx-unprivileged)
- Serves the built app on **:8080 — HTTP 200, HTML payload**
- This was the only failing component of the three jellyfin-ai builds in the PMOVES.AI #2695 arm64 validation — audio-processor (ffmpeg n8.1.2 **native aarch64**) and api-gateway (node 20) both pass

On merge, PMOVES.AI #2695's gitlink should advance to include this (the validation blocker clears).

💘 Generated with Crush